### PR TITLE
Switch bandits to Independent and add RP interactions

### DIFF
--- a/CfgFunctions.hpp
+++ b/CfgFunctions.hpp
@@ -21,6 +21,8 @@ class CfgFunctions
             class pickupLoot      {};
             class arrestPlayer    {};
             class endMission      {};
+            class addRPInteractions {};
+            class showID         {};
         };
     };
 };

--- a/description.ext
+++ b/description.ext
@@ -18,8 +18,8 @@
 */
 
 author      = "Modder";
-onLoadName  = "Cops and Robbers";
-onLoadMission = "Grundgerüst für einen Cops‑and‑Robbers‑Spielmodus";
+onLoadName  = "Cops and Robbers - Malden";
+onLoadMission = "Grundgerüst für einen Cops‑and‑Robbers‑Spielmodus auf Malden";
 loadScreen  = "\A3\ui_f\data\map_backgrounds\background_terrain_ca.paa";
 
 // Respawn‑Einstellungen: Spieler erscheinen an markierten Punkten (siehe editor‑Marker)

--- a/functions/fn_addRPInteractions.sqf
+++ b/functions/fn_addRPInteractions.sqf
@@ -1,0 +1,17 @@
+/*
+    Funktion: CR_fnc_addRPInteractions
+    Zweck: Fügt clientseitig einfache RP-Interaktionen hinzu. Aktuell
+    erhalten alle Spieler eine Aktion "Ausweis zeigen", mit der sie
+    anderen in der Nähe ihre Identität präsentieren können. Dies soll
+    Rollenspielgespräche zwischen Polizisten und Räubern fördern.
+*/
+
+if (!hasInterface) exitWith {};
+
+player addAction [
+    "Ausweis zeigen",
+    {
+        params ["_target", "_caller", "_actionId", "_arguments"];
+        [_caller] remoteExec ["CR_fnc_showID", 0];
+    }
+];

--- a/functions/fn_arrestPlayer.sqf
+++ b/functions/fn_arrestPlayer.sqf
@@ -20,8 +20,8 @@ if (side _caller != west) exitWith
 {
     hint "Nur Polizisten können Räuber verhaften!";
 };
-// Nur Räuber können verhaftet werden
-if (side _target != east) exitWith
+// Nur Räuber (INDEPENDENT) können verhaftet werden
+if (side _target != resistance) exitWith
 {
     hint "Ziel ist kein Räuber.";
 };
@@ -47,7 +47,7 @@ hint "Räuber wurde verhaftet!";
 [] spawn
 {
     sleep 5;
-    private _remaining = {side _x == east && isPlayer _x && !(_x getVariable ["CR_arrested", false])} count allUnits;
+    private _remaining = {side _x == resistance && isPlayer _x && !(_x getVariable ["CR_arrested", false])} count allUnits;
     if (_remaining == 0) then
     {
         [] call CR_fnc_endMission;

--- a/functions/fn_assignTasks.sqf
+++ b/functions/fn_assignTasks.sqf
@@ -46,9 +46,9 @@ switch (side player) do
             "Nehmt die Räuber fest oder neutralisiert sie.", 
             "Räuber festnehmen", "Festnahme", _bankPos] call _createTask;
     };
-    case east:
+    case resistance:
     {
-        // Räuber: Tresor plündern und Beute wegschaffen
+        // Räuber (INDEPENDENT): Tresor plündern und Beute wegschaffen
         CR_robberTask1 = [_playerSide, "CR_RobBank", 
             "Knackt den Tresor in der Bank und stehlt das Geld.", 
             "Bank ausrauben", "Raub", _bankPos] call _createTask;

--- a/functions/fn_endMission.sqf
+++ b/functions/fn_endMission.sqf
@@ -14,7 +14,7 @@ if (!isServer) exitWith {};
 // Prüfen, ob ein Räuber den Geldsack erfolgreich zur Fluchtzone gebracht hat
 private _lootDelivered = false;
 {
-    if (side _x == east && isPlayer _x) then
+    if (side _x == resistance && isPlayer _x) then
     {
         if (_x getVariable ["CR_lootDelivered", false]) then
         {

--- a/functions/fn_pickupLoot.sqf
+++ b/functions/fn_pickupLoot.sqf
@@ -15,8 +15,8 @@
 
 params ["_target", "_caller", "_actionId", "_arguments"];
 
-// Nur Räuber dürfen die Beute aufnehmen
-if (side _caller != east) exitWith
+// Nur Räuber (INDEPENDENT) dürfen die Beute aufnehmen
+if (side _caller != resistance) exitWith
 {
     hint "Nur Räuber können die Beute aufnehmen!";
 };

--- a/functions/fn_setupTeams.sqf
+++ b/functions/fn_setupTeams.sqf
@@ -6,7 +6,7 @@
     Für dieses Framework gehen wir davon aus, dass im Editor zwei
     Marker namens "police_spawn" und "robber_spawn" existieren.  Alle
     spielbaren Einheiten auf der Seite BLUFOR (west) gelten als
-    Polizisten, während OPFOR (east) die Räuber darstellen.  Die
+    Polizisten, während INDEPENDENT (resistance) die Räuber darstellen.  Die
     Einheiten werden an ihre entsprechenden Spawnpunkte versetzt und
     erhalten einfache Waffen.
 */
@@ -32,7 +32,7 @@ private _robberSpawn = getMarkerPos "robber_spawn";
                 _x addMagazine "30Rnd_9x21_Mag_SMG_02";
                 _x addItemToUniform "ACE_EarPlugs";
             };
-            case east:
+            case resistance:
             {
                 _x setPosATL _robberSpawn;
                 _x removeAllWeapons;

--- a/functions/fn_showID.sqf
+++ b/functions/fn_showID.sqf
@@ -1,0 +1,11 @@
+/*
+    Funktion: CR_fnc_showID
+    Zweck: Zeigt den Namen und die UID eines Spielers an. Wird über
+    `remoteExec` auf allen Clients ausgeführt, wenn jemand seinen
+    Ausweis zeigt.
+    Parameter:
+        0: OBJECT - Spieler, der seinen Ausweis zeigt
+*/
+
+params ["_unit"];
+hint format ["%1 zeigt seinen Ausweis\nUID: %2", name _unit, getPlayerUID _unit];

--- a/functions/fn_startRobbery.sqf
+++ b/functions/fn_startRobbery.sqf
@@ -14,8 +14,8 @@
 
 params ["_target", "_caller", "_actionId", "_arguments"];
 
-// Nur Räuber dürfen starten
-if (side _caller != east) exitWith
+// Nur Räuber (INDEPENDENT) dürfen starten
+if (side _caller != resistance) exitWith
 {
     hint "Nur Räuber können den Tresor knacken!";
 };
@@ -32,7 +32,7 @@ _duration = 60;
     // Beute erzeugen
     private _moneyBag = "Land_Money_F" createVehicle (getMarkerPos "bank_marker" vectorAdd [0,0,0]);
     _moneyBag setVariable ["CR_loot", true, true];
-    ["Der Tresor ist offen! Schnapp dir die Beute!", "PLAIN", 3] remoteExec ["BIS_fnc_showNotification", [east, west]];
+    ["Der Tresor ist offen! Schnapp dir die Beute!", "PLAIN", 3] remoteExec ["BIS_fnc_showNotification", [resistance, west]];
 };
 
 // Task‑Status aktualisieren: RobberTask1 auf „Succeeded“ setzen und RobberTask2 zuweisen

--- a/init.sqf
+++ b/init.sqf
@@ -25,4 +25,5 @@ if (isServer) then
 if (hasInterface) then
 {
     [] call CR_fnc_assignTasks;
+    [] call CR_fnc_addRPInteractions;
 };

--- a/mission.sqm
+++ b/mission.sqm
@@ -1,0 +1,114 @@
+version=53;
+class EditorData
+{
+    moveGridStep=1;
+    angleGridStep=0.2617994;
+    scaleGridStep=1;
+    autoGroupingDist=10;
+    toggles=1;
+    class ItemIDProvider
+    {
+        nextID=3;
+    };
+};
+class Mission
+{
+    addOns[]=
+    {
+        "A3_Characters_F_BLUFOR",
+        "A3_Characters_F_INDEP",
+        "A3_Characters_F_Common",
+        "A3_Map_Malden"
+    };
+    addOnsAuto[]=
+    {
+        "A3_Characters_F_BLUFOR",
+        "A3_Characters_F_INDEP",
+        "A3_Characters_F_Common",
+        "A3_Map_Malden"
+    };
+    randomSeed=123456;
+    class Entities
+    {
+        items=2;
+        class Item0
+        {
+            dataType="Group";
+            side="West";
+            class Entities
+            {
+                items=1;
+                class Item0
+                {
+                    dataType="Object";
+                    class PositionInfo
+                    {
+                        position[]={8585.9,47.6,2514.0};
+                        angles[]={0,0,0};
+                    };
+                    side="West";
+                    vehicle="B_Soldier_F";
+                    player="PLAYER";
+                    leader=1;
+                    skill=0.6;
+                };
+            };
+        };
+        class Item1
+        {
+            dataType="Group";
+            side="Guer";
+            class Entities
+            {
+                items=1;
+                class Item0
+                {
+                    dataType="Object";
+                    class PositionInfo
+                    {
+                        position[]={8591.9,47.6,2514.0};
+                        angles[]={0,0,0};
+                    };
+                    side="Guer";
+                    vehicle="I_Soldier_F";
+                    player="PLAY CDG";
+                    leader=1;
+                    skill=0.6;
+                };
+            };
+        };
+    };
+    class Intel
+    {
+        timeOfChanges=1800;
+        startWeather=0.3;
+        startWind=0.1;
+        startGust=0;
+        forecastWeather=0.3;
+        forecastWind=0.1;
+        forecastGust=0;
+        year=2035;
+        month=6;
+        day=24;
+        hour=12;
+        minute=0;
+    };
+};
+class Intro
+{
+    addOns[]={};
+    addOnsAuto[]={};
+    randomSeed=0;
+};
+class OutroWin
+{
+    addOns[]={};
+    addOnsAuto[]={};
+    randomSeed=0;
+};
+class OutroLoose
+{
+    addOns[]={};
+    addOnsAuto[]={};
+    randomSeed=0;
+};


### PR DESCRIPTION
## Summary
- Configure mission for Malden and clarify factions.
- Convert robber logic to use the Independent side instead of East.
- Add basic RP features: players can show IDs via new `addRPInteractions` and `showID` functions.

## Testing
- `sqflint functions/*.sqf` *(fails: command not found)*
- `pip install --quiet sqflint` *(fails: 403 forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc677b6288328b5a8f62fc0df9c50