### PR TITLE
Add gas station robbery with ACE progress

### DIFF
--- a/CfgFunctions.hpp
+++ b/CfgFunctions.hpp
@@ -25,6 +25,8 @@ class CfgFunctions
 
             class initRobberyTargets {};
             class addRobberyActions {};
+            class robGasStation   {};
+            class spawnGasLoot    {};
             class triggerAlarm   {};
             class notifyCops     {};
             class spawnVehicle   {};

--- a/functions/fn_addRobberyActions.sqf
+++ b/functions/fn_addRobberyActions.sqf
@@ -21,7 +21,7 @@ switch (_type) do
             if (side _caller != civilian) exitWith {};
             if (_target getVariable ["robbed", false]) exitWith { hint "Bereits ausgeraubt"; };
             _target setVariable ["robbed", true, true];
-            [getPos _target, "Überfall auf eine Tankstelle!"] remoteExec ["CR_fnc_triggerAlarm", 2];
+            [_target, _caller] call CR_fnc_robGasStation;
         }];
     };
     case "atm":

--- a/functions/fn_robGasStation.sqf
+++ b/functions/fn_robGasStation.sqf
@@ -1,0 +1,35 @@
+/*
+    Funktion: CR_fnc_robGasStation
+    Zweck: Führt den Tankstellenraub mit einer Fortschrittsanzeige durch
+    und löst einen Alarm aus. Nach Ablauf von 150 Sekunden wird auf dem
+    Server eine Kiste mit einer Übungsmine gespawnt.
+    Parameter:
+        0: OBJECT - Tankstellenobjekt
+        1: OBJECT - auslösender Spieler
+*/
+
+params ["_target", "_caller"];
+
+if (!hasInterface) exitWith {};
+
+// Alarm für Polizisten auslösen
+[getPos _target, "Überfall auf eine Tankstelle!"] remoteExec ["CR_fnc_triggerAlarm", 2];
+
+[
+    150,
+    _target,
+    {
+        // fertig
+        params ["_target", "_caller"];
+        [_target] remoteExec ["CR_fnc_spawnGasLoot", 2];
+    },
+    {
+        // abgebrochen
+        params ["_target", "_caller"];
+        _target setVariable ["robbed", false, true];
+    },
+    "Tankstelle wird ausgeraubt...",
+    _target,
+    _caller
+] call ace_common_fnc_progressBar;
+

--- a/functions/fn_spawnGasLoot.sqf
+++ b/functions/fn_spawnGasLoot.sqf
@@ -1,0 +1,15 @@
+/*
+    Funktion: CR_fnc_spawnGasLoot
+    Zweck: Spawnt eine Kiste mit einer Übungsmine an der Tankstelle
+    nach erfolgreichem Raub.
+    Parameter:
+        0: OBJECT - Tankstellenobjekt
+*/
+
+if (!isServer) exitWith {};
+
+params ["_target"];
+
+private _crate = "Box_NATO_Ammo_F" createVehicle (getPos _target);
+_crate addItemCargoGlobal ["TrainingMine_Mag", 1];
+


### PR DESCRIPTION
## Summary
- Add dedicated gas station robbery function with ACE progress bar and alarm
- Spawn loot crate containing a TrainingMine_Mag on successful robbery
- Register new functions and integrate action into robbery targets

## Testing
- `sqflint -V` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68beb257a7488328bb4b83dca34d600a