### PR TITLE
Use ACE actions for robbery targets

### DIFF
--- a/functions/fn_addRobberyActions.sqf
+++ b/functions/fn_addRobberyActions.sqf
@@ -16,23 +16,37 @@ switch (_type) do
 {
     case "gas":
     {
-        _obj addAction ["Tankstelle ausrauben", {
-            params ["_target", "_caller"];
-            if (side _caller != civilian) exitWith {};
-            if (_target getVariable ["robbed", false]) exitWith { hint "Bereits ausgeraubt"; };
-            _target setVariable ["robbed", true, true];
-            [_target, _caller] call CR_fnc_robGasStation;
-        }];
+        private _action = [
+            "robGasStation",
+            "Tankstelle ausrauben",
+            "",
+            {
+                params ["_target", "_player", "_args"];
+                if (side _player != civilian) exitWith {};
+                if (_target getVariable ["robbed", false]) exitWith { hint "Bereits ausgeraubt"; };
+                _target setVariable ["robbed", true, true];
+                [_target, _player] call CR_fnc_robGasStation;
+            },
+            { true }
+        ] call ace_interact_menu_fnc_createAction;
+        [_obj, 0, ["ACE_MainActions"], _action] call ace_interact_menu_fnc_addActionToObject;
     };
     case "atm":
     {
-        _obj addAction ["ATM knacken", {
-            params ["_target", "_caller"];
-            if (side _caller != civilian) exitWith {};
-            if (_target getVariable ["robbed", false]) exitWith { hint "Bereits geknackt"; };
-            _target setVariable ["robbed", true, true];
-            [getPos _target, "Ein ATM wird geknackt!"] remoteExec ["CR_fnc_triggerAlarm", 2];
-        }];
+        private _action = [
+            "robATM",
+            "ATM knacken",
+            "",
+            {
+                params ["_target", "_player", "_args"];
+                if (side _player != civilian) exitWith {};
+                if (_target getVariable ["robbed", false]) exitWith { hint "Bereits geknackt"; };
+                _target setVariable ["robbed", true, true];
+                [getPos _target, "Ein ATM wird geknackt!"] remoteExec ["CR_fnc_triggerAlarm", 2];
+            },
+            { true }
+        ] call ace_interact_menu_fnc_createAction;
+        [_obj, 0, ["ACE_MainActions"], _action] call ace_interact_menu_fnc_addActionToObject;
     };
     default {}; // für unbekannte Typen keine Aktion
 };


### PR DESCRIPTION
## Summary
- Replace robbery addActions with ACE interaction menu actions
- Keep civilian-only and robbed-state logic in action callbacks

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68beb843efa88328bee5c6c6157bab2c