### PR TITLE
Use container only when clearing ACE arsenal box

### DIFF
--- a/functions/fn_openArsenal.sqf
+++ b/functions/fn_openArsenal.sqf
@@ -34,6 +34,6 @@ private _items = switch (side _caller) do
     };
 };
 
-[_box, _items] call ace_arsenal_fnc_clearBox;
+[_box] call ace_arsenal_fnc_clearBox;
 [_box, _items] call ace_arsenal_fnc_addVirtualItems;
 [_box, _caller, true] call ace_arsenal_fnc_openBox;


### PR DESCRIPTION
## Summary
- call `ace_arsenal_fnc_clearBox` with only the container

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68beb8457e3083289fea3bdbcf15ecb4