### PR TITLE
Add safehouse objective and dynamic robbery tasks

### DIFF
--- a/CfgFunctions.hpp
+++ b/CfgFunctions.hpp
@@ -34,6 +34,17 @@ class CfgFunctions
             class addArsenalAction {};
             class openArsenal   {};
             class addGarageActions {};
+
+            // Neue Funktionen für Safehouse- und Task-Logik
+            class clearCopMarkers {};
+            class assignInterceptTask {};
+            class assignSafehouseTask {};
+            class addLaptopAction {};
+            class postGasRobbery {};
+            class safehouseSuccess {};
+            class finishSafehouseRobber {};
+            class finishSafehouseCops {};
+            class robberyPreventedCops {};
           };
       };
   };

--- a/functions/fn_addLaptopAction.sqf
+++ b/functions/fn_addLaptopAction.sqf
@@ -1,0 +1,19 @@
+/*
+    Funktion: CR_fnc_addLaptopAction
+    Zweck: Fügt dem Safehouse-Laptop eine Aktion hinzu, die nur von
+    Räubern genutzt werden kann.
+    Parameter:
+        0: OBJECT - Laptop
+*/
+
+params ["_laptop"];
+if (!hasInterface) exitWith {};
+
+_laptop addAction [
+    "Daten löschen",
+    {
+        params ["_target", "_caller", "_actionId", "_args"];
+        if (side _caller != civilian) exitWith {};
+        [_caller] remoteExec ["CR_fnc_safehouseSuccess", 2];
+    }
+];

--- a/functions/fn_arrestPlayer.sqf
+++ b/functions/fn_arrestPlayer.sqf
@@ -36,9 +36,9 @@ if ((player distance _target) > 3) exitWith
 _target disableAI "MOVE";
 _target playActionNow "Surrender";
 _target setCaptive true;
-// Task des Räubers als fehlgeschlagen markieren
-if (!isNil "CR_robberTask1") then { CR_robberTask1 setTaskState "Failed"; };
-if (!isNil "CR_robberTask2") then { CR_robberTask2 setTaskState "Failed"; };
+// Tasks des Räubers als fehlgeschlagen markieren
+if (!isNil "CR_robTaskRob") then { CR_robTaskRob setTaskState "Failed"; };
+if (!isNil "CR_robTaskSafehouse") then { CR_robTaskSafehouse setTaskState "Failed"; };
 
 // Polizist erhält eine Erfolgsmeldung
 hint "Räuber wurde verhaftet!";

--- a/functions/fn_assignInterceptTask.sqf
+++ b/functions/fn_assignInterceptTask.sqf
@@ -1,0 +1,23 @@
+/*
+    Funktion: CR_fnc_assignInterceptTask
+    Zweck: Weist den Polizisten nach einem erfolgreichen Überfall einen
+    neuen Task zum Abfangen der Räuber zu.
+    Parameter:
+        0: ARRAY - Position des Überfalls (für letzte bekannte Position)
+*/
+
+params ["_pos"];
+if (!hasInterface || side player != west) exitWith {};
+
+if (!isNil "CR_copTaskPrevent") then {
+    CR_copTaskPrevent setTaskState "Failed";
+};
+
+CR_copTaskIntercept = player createSimpleTask ["CR_InterceptRobbers"];
+CR_copTaskIntercept setSimpleTaskDescription [
+    "Finde und stoppe die Räuber, bevor sie entkommen.",
+    "Räuber abfangen",
+    "Abfangen"
+];
+CR_copTaskIntercept setSimpleTaskDestination _pos;
+CR_copTaskIntercept setTaskState "Assigned";

--- a/functions/fn_assignSafehouseTask.sqf
+++ b/functions/fn_assignSafehouseTask.sqf
@@ -1,0 +1,23 @@
+/*
+    Funktion: CR_fnc_assignSafehouseTask
+    Zweck: Weist den Räubern einen Task zu, das Safehouse zu erreichen
+    und dort den Laptop zu benutzen.
+    Parameter:
+        0: ARRAY - Position des Safehouses
+*/
+
+params ["_pos"];
+if (!hasInterface || side player != civilian) exitWith {};
+
+if (!isNil "CR_robTaskRob") then {
+    CR_robTaskRob setTaskState "Succeeded";
+};
+
+CR_robTaskSafehouse = player createSimpleTask ["CR_Safehouse"];
+CR_robTaskSafehouse setSimpleTaskDescription [
+    "Fahre zum Safehouse und interagiere mit dem Laptop, um die Fahndung zu beenden.",
+    "Zum Safehouse",
+    "Safehouse"
+];
+CR_robTaskSafehouse setSimpleTaskDestination _pos;
+CR_robTaskSafehouse setTaskState "Assigned";

--- a/functions/fn_assignTasks.sqf
+++ b/functions/fn_assignTasks.sqf
@@ -18,13 +18,25 @@ switch (side player) do
 {
     case west:
     {
-        CR_copTask1 = ["CR_Respond", "Reagiere auf Alarme und verhindere Raubüberfälle.",
-            "Raubüberfälle verhindern", "Cops", getMarkerPos "cop_spawn"] call _createTask;
+        // Standardaufgabe für Polizisten: auf Streife gehen
+        CR_copTaskPatrol = [
+            "CR_Patrol",
+            "Streife fahren, auf Auffälligkeiten achten.",
+            "Streife fahren",
+            "Cops",
+            getMarkerPos "cop_spawn"
+        ] call _createTask;
     };
     case civilian:
     {
-        CR_robTask1 = ["CR_RobTargets", "Raube Tankstellen, ATMs oder den Tresor aus.",
-            "Raubzüge durchführen", "Raub", getMarkerPos "robber_spawn"] call _createTask;
+        // Grundaufgabe für Räuber: geeignete Ziele auskundschaften
+        CR_robTaskRob = [
+            "CR_RobTargets",
+            "Raube Tankstellen, ATMs oder den Tresor aus.",
+            "Raubzüge durchführen",
+            "Raub",
+            getMarkerPos "robber_spawn"
+        ] call _createTask;
     };
     default {};
 };

--- a/functions/fn_clearCopMarkers.sqf
+++ b/functions/fn_clearCopMarkers.sqf
@@ -1,0 +1,12 @@
+/*
+    Funktion: CR_fnc_clearCopMarkers
+    Zweck: Entfernt alle aktuell gespeicherten Polizeimarker.
+*/
+
+if (!hasInterface || side player != west) exitWith {};
+
+if (isNil "CR_policeMarkers") exitWith {};
+{
+    deleteMarkerLocal _x;
+} forEach CR_policeMarkers;
+CR_policeMarkers = [];

--- a/functions/fn_finishSafehouseCops.sqf
+++ b/functions/fn_finishSafehouseCops.sqf
@@ -1,0 +1,19 @@
+/*
+    Funktion: CR_fnc_finishSafehouseCops
+    Zweck: Setzt den Abfang-Task der Polizei auf "Failed" und entfernt
+    alle Marker. Anschließend wird die Streifenaufgabe wieder aktiviert.
+*/
+
+if (!hasInterface || side player != west) exitWith {};
+
+if (!isNil "CR_copTaskIntercept") then {
+    CR_copTaskIntercept setTaskState "Failed";
+};
+
+// Alle Fahndungsmarker entfernen
+[] call CR_fnc_clearCopMarkers;
+
+// Streifenaufgabe erneut zuweisen
+if (!isNil "CR_copTaskPatrol") then {
+    CR_copTaskPatrol setTaskState "Assigned";
+};

--- a/functions/fn_finishSafehouseRobber.sqf
+++ b/functions/fn_finishSafehouseRobber.sqf
@@ -1,0 +1,10 @@
+/*
+    Funktion: CR_fnc_finishSafehouseRobber
+    Zweck: Schließt den Safehouse-Task für Räuber ab.
+*/
+
+if (!hasInterface || side player != civilian) exitWith {};
+
+if (!isNil "CR_robTaskSafehouse") then {
+    CR_robTaskSafehouse setTaskState "Succeeded";
+};

--- a/functions/fn_notifyCops.sqf
+++ b/functions/fn_notifyCops.sqf
@@ -12,10 +12,25 @@ params ["_pos", "_message"];
 
 if (side player != west) exitWith {};
 
+// Marker erzeugen und Namen speichern, damit er später gelöscht werden kann
+if (isNil "CR_policeMarkers") then { CR_policeMarkers = [] };
 private _markerName = format ["robbery_%1", diag_tickTime];
 private _m = createMarkerLocal [_markerName, _pos];
 _m setMarkerType "mil_warning";
 _m setMarkerColor "ColorRed";
 _m setMarkerText "Raub";
+CR_policeMarkers pushBack _markerName;
+
+// Aufgabe zum Verhindern des Überfalls zuweisen
+if (isNil "CR_copTaskPrevent") then {
+    CR_copTaskPrevent = player createSimpleTask ["CR_PreventRobbery"];
+    CR_copTaskPrevent setSimpleTaskDescription [
+        "Verhindere den Überfall auf die markierte Position.",
+        "Überfall verhindern",
+        "Überfall"
+    ];
+};
+CR_copTaskPrevent setSimpleTaskDestination _pos;
+CR_copTaskPrevent setTaskState "Assigned";
 
 [_message] call BIS_fnc_showSubtitle;

--- a/functions/fn_pickupLoot.sqf
+++ b/functions/fn_pickupLoot.sqf
@@ -31,10 +31,11 @@ if (!(_target getVariable ["CR_loot", false])) exitWith
 _target attachTo [_caller, [0, 0.4, -0.1], "Spine3"];
 _target setVariable ["CR_lootCarrier", _caller, true];
 
-// Task‑Status aktualisieren
-if (!isNil "CR_robberTask2") then
+// Task‑Status aktualisieren: Safehouse-Aufgabe aktivieren, falls vorhanden
+if (!isNil "CR_robTaskSafehouse") then
 {
-    CR_robberTask2 setTaskState "Assigned";
+    CR_robTaskSafehouse setTaskState "Assigned";
 };
 
-hint "Du hast die Beute aufgenommen! Bringe sie zur Fluchtzone.";
+  hint "Du hast die Beute aufgenommen! Bringe sie zur Fluchtzone.";
+

--- a/functions/fn_postGasRobbery.sqf
+++ b/functions/fn_postGasRobbery.sqf
@@ -1,0 +1,28 @@
+/*
+    Funktion: CR_fnc_postGasRobbery
+    Zweck: Wird vom Server aufgerufen, wenn der Tankstellenraub
+    erfolgreich abgeschlossen wurde. Wählt ein zufälliges Safehouse,
+    spawnt dort einen Laptop und weist neue Tasks zu.
+    Parameter:
+        0: ARRAY - Position des Überfalls
+*/
+
+if (!isServer) exitWith {};
+params ["_robPos"];
+
+// Ein Safehouse mindestens 5 km entfernt suchen
+private _houses = nearestObjects [_robPos, ["House"], 20000];
+_houses = _houses select { _x distance2D _robPos > 5000 };
+_houses = _houses call BIS_fnc_arrayShuffle;
+if (_houses isEqualTo []) exitWith {};
+
+private _house = _houses select 0;
+private _safePos = getPos _house;
+
+private _laptop = "Land_Laptop_03_black_F" createVehicle _safePos;
+// Aktion auf allen Clients hinzufügen
+[_laptop] remoteExec ["CR_fnc_addLaptopAction", 0, _laptop];
+
+// Tasks zuweisen
+[_safePos] remoteExec ["CR_fnc_assignSafehouseTask", civilian];
+[_robPos]  remoteExec ["CR_fnc_assignInterceptTask", west];

--- a/functions/fn_robGasStation.sqf
+++ b/functions/fn_robGasStation.sqf
@@ -22,11 +22,13 @@ if (!hasInterface) exitWith {};
         // fertig
         params ["_target", "_caller"];
         [_target] remoteExec ["CR_fnc_spawnGasLoot", 2];
+        [getPos _target] remoteExec ["CR_fnc_postGasRobbery", 2];
     },
     {
         // abgebrochen
         params ["_target", "_caller"];
         _target setVariable ["robbed", false, true];
+        [] remoteExec ["CR_fnc_robberyPreventedCops", west];
     },
     "Tankstelle wird ausgeraubt...",
     _target,

--- a/functions/fn_robberyPreventedCops.sqf
+++ b/functions/fn_robberyPreventedCops.sqf
@@ -1,0 +1,16 @@
+/*
+    Funktion: CR_fnc_robberyPreventedCops
+    Zweck: Aktualisiert Polizeiaufgaben, wenn ein Überfall vereitelt wurde.
+*/
+
+if (!hasInterface || side player != west) exitWith {};
+
+if (!isNil "CR_copTaskPrevent") then {
+    CR_copTaskPrevent setTaskState "Succeeded";
+};
+
+// Marker entfernen und Streifenaufgabe aktiv lassen
+[] call CR_fnc_clearCopMarkers;
+if (!isNil "CR_copTaskPatrol") then {
+    CR_copTaskPatrol setTaskState "Assigned";
+};

--- a/functions/fn_safehouseSuccess.sqf
+++ b/functions/fn_safehouseSuccess.sqf
@@ -1,0 +1,13 @@
+/*
+    Funktion: CR_fnc_safehouseSuccess
+    Zweck: Wird vom Server aufgerufen, wenn ein Räuber im Safehouse den
+    Laptop benutzt hat. Aktualisiert die Tasks und entfernt Marker.
+    Parameter:
+        0: OBJECT - Räuber, der die Aktion ausgeführt hat (nicht genutzt)
+*/
+
+if (!isServer) exitWith {};
+
+// Aufgaben aktualisieren
+[] remoteExec ["CR_fnc_finishSafehouseRobber", civilian];
+[] remoteExec ["CR_fnc_finishSafehouseCops", west];

--- a/functions/fn_startRobbery.sqf
+++ b/functions/fn_startRobbery.sqf
@@ -35,9 +35,8 @@ _duration = 60;
     ["Der Tresor ist offen! Schnapp dir die Beute!", "PLAIN", 3] remoteExec ["BIS_fnc_showNotification", [civilian, west]];
 };
 
-// Task‑Status aktualisieren: RobberTask1 auf „Succeeded“ setzen und RobberTask2 zuweisen
-if (!isNil "CR_robberTask1") then
+// Task‑Status aktualisieren: Grundaufgabe der Räuber als erledigt markieren
+if (!isNil "CR_robTaskRob") then
 {
-    CR_robberTask1 setTaskState "Succeeded";
-    CR_robberTask2 setTaskState "Assigned";
+    CR_robTaskRob setTaskState "Succeeded";
 };


### PR DESCRIPTION
## Summary
- Add patrol baseline tasks for police and updated robbery task setup
- Generate random safehouse with laptop after successful gas-station robbery and assign corresponding robber/cop tasks
- Clear police markers and fail intercept tasks when laptop is used or robbery is prevented

## Testing
- `ls tests` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68beca86853883288bc3d932e5a2e2eb