### PR TITLE
Ensure network sync for arsenal and vehicle spawners

### DIFF
--- a/functions/fn_setupTeams.sqf
+++ b/functions/fn_setupTeams.sqf
@@ -44,14 +44,19 @@ private _robberSpawn = getMarkerPos "robber_spawn";
 
 // Arsenal-Kisten
 private _copArsenal = "B_supplyCrate_F" createVehicle (getMarkerPos "cop_arsenal");
-[_copArsenal, west] remoteExec ["CR_fnc_addArsenalAction", 0, true];
+// Warten, bis das Objekt im Netzwerk bekannt ist, bevor die Aktion verteilt wird
+sleep 1;
+[_copArsenal, west] remoteExec ["CR_fnc_addArsenalAction", -2, true];
 
 private _robberArsenal = "B_supplyCrate_F" createVehicle (getMarkerPos "robber_arsenal");
-[_robberArsenal, civilian] remoteExec ["CR_fnc_addArsenalAction", 0, true];
+sleep 1;
+[_robberArsenal, civilian] remoteExec ["CR_fnc_addArsenalAction", -2, true];
 
 // Fahrzeug-Spawner
 private _copPad = "Land_HelipadEmpty_F" createVehicle (getMarkerPos "cop_vehicle_spawn");
-[_copPad, west] remoteExec ["CR_fnc_addGarageActions", 0, true];
+sleep 1;
+[_copPad, west] remoteExec ["CR_fnc_addGarageActions", -2, true];
 
 private _robberPad = "Land_HelipadEmpty_F" createVehicle (getMarkerPos "robber_vehicle_spawn");
-[_robberPad, civilian] remoteExec ["CR_fnc_addGarageActions", 0, true];
+sleep 1;
+[_robberPad, civilian] remoteExec ["CR_fnc_addGarageActions", -2, true];


### PR DESCRIPTION
## Summary
- wait for created crates and pads to propagate before distributing ACE actions
- target remote execution to clients only to avoid null object errors

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bf1664327483289c7d0f215587d87b