### PR TITLE
Add ACE interaction for vault and update robbery target setup

### DIFF
--- a/functions/fn_addRobberyActions.sqf
+++ b/functions/fn_addRobberyActions.sqf
@@ -48,5 +48,22 @@ switch (_type) do
         ] call ace_interact_menu_fnc_createAction;
         [_obj, 0, ["ACE_MainActions"], _action] call ace_interact_menu_fnc_addActionToObject;
     };
+    case "vault":
+    {
+        private _action = [
+            "robVault",
+            "Tresor knacken",
+            "",
+            {
+                params ["_target", "_player", "_args"];
+                if (side _player != civilian) exitWith {};
+                if (_target getVariable ["robbed", false]) exitWith { hint "Bereits geknackt"; };
+                _target setVariable ["robbed", true, true];
+                [getPos _target, "Ein Tresor wird geknackt!"] remoteExec ["CR_fnc_triggerAlarm", 2];
+            },
+            { true }
+        ] call ace_interact_menu_fnc_createAction;
+        [_obj, 0, ["ACE_MainActions"], _action] call ace_interact_menu_fnc_addActionToObject;
+    };
     default {}; // für unbekannte Typen keine Aktion
 };

--- a/functions/fn_initRobberyTargets.sqf
+++ b/functions/fn_initRobberyTargets.sqf
@@ -1,28 +1,30 @@
 /*
     Funktion: CR_fnc_initRobberyTargets
     Zweck: Initialisiert Tankstellen, Geldautomaten und einen zufälligen Tresor.
-    Bei Interaktion oder Näherung wird ein Alarm ausgelöst.
+    Bei Interaktion wird ein Alarm ausgelöst.
 */
 
 if (!isServer) exitWith {};
 
-// Tankstellen
-private _gasMarkers = ["gas_station_1", "gas_station_2", "gas_station_3"];
+// Tankstellen (NPCs)
+private _gasTargets = ["gas_station_1", "gas_station_2", "gas_station_3"];
 {
-    private _pos = getMarkerPos _x;
-    private _obj = "Land_FuelStation_Feed_F" createVehicle _pos;
-    _obj setVariable ["CR_target", "gas", true];
-    [_obj] remoteExec ["CR_fnc_addRobberyActions", 0, _obj];
-} forEach _gasMarkers;
+    private _obj = missionNamespace getVariable [_x, objNull];
+    if (!isNull _obj) then {
+        _obj setVariable ["CR_target", "gas", true];
+        [_obj] remoteExec ["CR_fnc_addRobberyActions", 0, _obj];
+    };
+} forEach _gasTargets;
 
-// Geldautomaten
-private _atmMarkers = ["atm_1", "atm_2", "atm_3", "atm_4", "atm_5"];
+// Geldautomaten (platzierte Objekte)
+private _atmTargets = ["ATM_1", "ATM_2", "ATM_3", "ATM_4", "ATM_5"];
 {
-    private _pos = getMarkerPos _x;
-    private _obj = "Land_ATM_01_F" createVehicle _pos;
-    _obj setVariable ["CR_target", "atm", true];
-    [_obj] remoteExec ["CR_fnc_addRobberyActions", 0, _obj];
-} forEach _atmMarkers;
+    private _obj = missionNamespace getVariable [_x, objNull];
+    if (!isNull _obj) then {
+        _obj setVariable ["CR_target", "atm", true];
+        [_obj] remoteExec ["CR_fnc_addRobberyActions", 0, _obj];
+    };
+} forEach _atmTargets;
 
 // Tresor zufällig platzieren
 private _areaCenter = getMarkerPos "vault_area";
@@ -34,20 +36,5 @@ private _vaultPos = [
 ];
 private _vault = "Land_Safe_F" createVehicle _vaultPos;
 _vault setVariable ["CR_target", "vault", true];
+[_vault] remoteExec ["CR_fnc_addRobberyActions", 0, _vault];
 
-// Tresor näherungsüberwachung
-[_vault] spawn
-{
-    params ["_safe"];
-    while {alive _safe} do
-    {
-        {
-            if (side _x == civilian && {_x distance _safe < 2} && !(_safe getVariable ["alarm", false])) then
-            {
-                _safe setVariable ["alarm", true, true];
-                [getPos _safe, "Ein Tresor wird geknackt!"] call CR_fnc_triggerAlarm;
-            };
-        } forEach allPlayers;
-        sleep 1;
-    };
-};


### PR DESCRIPTION
## Summary
- Support cracking the vault via ACE interaction and trigger an alarm
- Initialize vault, gas station NPCs, and ATMs with robbery actions on creation instead of proximity checks

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68bf188084f08328a521774ce4c3ac8c