### PR TITLE
Use placed objects for interactions and fix robbery target setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Cops-and-Robbers ist ein kooperatives Szenario für Arma 3, in dem zwei Teams ge
 - Nach einem erfolgreichen Überfall folgt eine Safehouse-Phase, in der die Räuber sich verstecken und die Polizei nach ihnen fahndet.
 
 Die Mission bringt bereits drei benannte Tankstellen-NPCs (`gas_station_1` bis `gas_station_3`),
-einen Geldautomaten (`ATM_1`) und einen Tresor (`tresor`) mit. Diese Objekte werden zur Laufzeit
-über `CR_fnc_initRobberyTargets` mit ACE-Interaktionen für Überfälle versehen.
+fünf Geldautomaten (`atm_1` bis `atm_5`) und einen Tresor (`tresor`) mit. Diese Objekte werden zur
+Laufzeit über `CR_fnc_initRobberyTargets` mit ACE-Interaktionen für Überfälle versehen.
 
 ## Funktionsreferenz
 | Funktion | Beschreibung |

--- a/functions/fn_addRobberyActions.sqf
+++ b/functions/fn_addRobberyActions.sqf
@@ -3,7 +3,7 @@
     Zweck: Fügt einem Zielobjekt die passenden Aktionen für Räuber hinzu.
     Wird vom Server für jedes Ziel per remoteExec auf alle Clients aufgerufen.
     Die Zielobjekte stammen aus der mission.sqm und werden in
-    CR_fnc_initRobberyTargets anhand ihres Namens (gas_station_*, ATM_*,
+    CR_fnc_initRobberyTargets anhand ihres Namens (gas_station_*, atm_*,
     tresor) vorbereitet.
     Parameter:
         0: OBJECT - Zielobjekt

--- a/functions/fn_initRobberyTargets.sqf
+++ b/functions/fn_initRobberyTargets.sqf
@@ -1,12 +1,21 @@
+/*
+    Funktion: CR_fnc_initRobberyTargets
+    Zweck:    Sucht in der mission.sqm nach benannten Zielen und
+              statte sie mit ACE-Raubaktionen aus.
+              Unterstützte Präfixe:
+                - gas_station_* für Tankstellen-NPCs
+                - atm_*         für Geldautomaten
 
+    Diese Funktion wird nur auf dem Server ausgeführt.
+*/
 
 if (!isServer) exitWith {};
 
-// Objektvariablen aus mission.sqm ermitteln
+// Alle Objektvariablen sammeln
 private _vars = allVariables missionNamespace;
 
 // Tankstellen (NPCs)
-{   
+{
     private _obj = missionNamespace getVariable [_x, objNull];
     if (!isNull _obj) then {
         _obj setVariable ["CR_target", "gas", true];
@@ -15,47 +24,17 @@ private _vars = allVariables missionNamespace;
 } forEach (_vars select { _x find "gas_station_" == 0 });
 
 // Geldautomaten (platzierte Objekte)
-{   
-    private _obj = missionNamespace getVariable [_x, objNull];
-    if (!isNull _obj) then {
-        _obj setVariable ["CR_target", "atm", true];
-        [_obj] remoteExec ["CR_fnc_addRobberyActions", 0, _obj];
-    };
-} forEach (_vars select { _x find "ATM_" == 0 });
-
-// Tresore (platzierte Safes)
-{   
-    private _obj = missionNamespace getVariable [_x, objNull];
-    if (!isNull _obj) then {
-        _obj setVariable ["CR_target", "vault", true];
-        [_obj] remoteExec ["CR_fnc_addRobberyActions", 0, _obj];
-    };
-} forEach (_vars select { _x find "tresor" == 0 });
-
-=======
-// Tankstellen (NPCs)
-private _gasTargets = ["gas_station_1", "gas_station_2", "gas_station_3"];
-{
-    private _obj = missionNamespace getVariable [_x, objNull];
-    if (!isNull _obj) then {
-        _obj setVariable ["CR_target", "gas", true];
-        [_obj] remoteExec ["CR_fnc_addRobberyActions", 0, _obj];
-    };
-} forEach _gasTargets;
-
-// Geldautomaten (platzierte Objekte)
-private _atmTargets = ["ATM_1", "ATM_2", "ATM_3", "ATM_4", "ATM_5"];
 {
     private _obj = missionNamespace getVariable [_x, objNull];
     if (!isNull _obj) then {
         _obj setVariable ["CR_target", "atm", true];
         [_obj] remoteExec ["CR_fnc_addRobberyActions", 0, _obj];
     };
-} forEach _atmTargets;
+} forEach (_vars select { _x find "atm_" == 0 });
 
-// Tresor zufällig platzieren
+// Tresor zufällig innerhalb des Bereichs platzieren
 private _areaCenter = getMarkerPos "vault_area";
-private _areaSize = getMarkerSize "vault_area";
+private _areaSize   = getMarkerSize "vault_area";
 private _vaultPos = [
     (_areaCenter select 0) + (random ((_areaSize select 0) * 2) - (_areaSize select 0)),
     (_areaCenter select 1) + (random ((_areaSize select 1) * 2) - (_areaSize select 1)),

--- a/functions/fn_setupTeams.sqf
+++ b/functions/fn_setupTeams.sqf
@@ -42,16 +42,24 @@ private _robberSpawn = getMarkerPos "robber_spawn";
     };
 } forEach allUnits;
 
-// Arsenal-Kisten
-private _copArsenal = "B_supplyCrate_F" createVehicle (getMarkerPos "cop_arsenal");
-[_copArsenal, west] remoteExec ["CR_fnc_addArsenalAction", 0, true];
+// Arsenal-Kisten (bereits platzierte Objekte)
+private _copArsenal = missionNamespace getVariable ["cop_arsenal", objNull];
+if (!isNull _copArsenal) then {
+    [_copArsenal, west] remoteExec ["CR_fnc_addArsenalAction", 0, true];
+};
 
-private _robberArsenal = "B_supplyCrate_F" createVehicle (getMarkerPos "robber_arsenal");
-[_robberArsenal, civilian] remoteExec ["CR_fnc_addArsenalAction", 0, true];
+private _robberArsenal = missionNamespace getVariable ["robber_arsenal", objNull];
+if (!isNull _robberArsenal) then {
+    [_robberArsenal, civilian] remoteExec ["CR_fnc_addArsenalAction", 0, true];
+};
 
-// Fahrzeug-Spawner
-private _copPad = "Land_HelipadEmpty_F" createVehicle (getMarkerPos "cop_vehicle_spawn");
-[_copPad, west] remoteExec ["CR_fnc_addGarageActions", 0, true];
+// Fahrzeug-Spawner (Cargo-Netze)
+private _copPad = missionNamespace getVariable ["cop_vehicle_spawn", objNull];
+if (!isNull _copPad) then {
+    [_copPad, west] remoteExec ["CR_fnc_addGarageActions", 0, true];
+};
 
-private _robberPad = "Land_HelipadEmpty_F" createVehicle (getMarkerPos "robber_vehicle_spawn");
-[_robberPad, civilian] remoteExec ["CR_fnc_addGarageActions", 0, true];
+private _robberPad = missionNamespace getVariable ["robber_vehicle_spawn", objNull];
+if (!isNull _robberPad) then {
+    [_robberPad, civilian] remoteExec ["CR_fnc_addGarageActions", 0, true];
+};


### PR DESCRIPTION
## Summary
- detect `gas_station_*` and `atm_*` objects and attach robbery actions
- use pre-placed cargo nets for arsenal and vehicle spawns
- document ATM naming and prefixes

## Testing
- ⚠️ `sqflint` (command not found)

------
https://chatgpt.com/codex/tasks/task_e_68bf3040bcd083288c46a3c9e7465024