### PR TITLE
Ensure ACE interactions run after init and whitelist remote exec

### DIFF
--- a/description.ext
+++ b/description.ext
@@ -37,3 +37,38 @@ class Header
 
 // Verweise auf zusätzliche Konfigurationsdateien
 #include "CfgFunctions.hpp"
+
+class CfgRemoteExec
+{
+    class Functions
+    {
+        mode = 1;
+        jip = 1;
+
+        class BIS_fnc_endMission { allowedTargets = 0; };
+        class BIS_fnc_showNotification { allowedTargets = 0; };
+
+        class CR_fnc_addRobberyActions      { allowedTargets = 0; };
+        class CR_fnc_addArsenalAction       { allowedTargets = 0; };
+        class CR_fnc_addGarageActions       { allowedTargets = 0; };
+        class CR_fnc_addLaptopAction       { allowedTargets = 0; };
+        class CR_fnc_assignSafehouseTask   { allowedTargets = 1; };
+        class CR_fnc_assignInterceptTask   { allowedTargets = 1; };
+        class CR_fnc_notifyCops            { allowedTargets = 1; };
+        class CR_fnc_triggerAlarm          { allowedTargets = 2; };
+        class CR_fnc_showID                { allowedTargets = 0; };
+        class CR_fnc_spawnVehicle          { allowedTargets = 2; };
+        class CR_fnc_spawnGasLoot          { allowedTargets = 2; };
+        class CR_fnc_postGasRobbery        { allowedTargets = 2; };
+        class CR_fnc_robberyPreventedCops  { allowedTargets = 1; };
+        class CR_fnc_safehouseSuccess      { allowedTargets = 2; };
+        class CR_fnc_finishSafehouseRobber { allowedTargets = 1; };
+        class CR_fnc_finishSafehouseCops   { allowedTargets = 1; };
+    };
+
+    class Commands
+    {
+        mode = 0;
+        jip = 0;
+    };
+};

--- a/functions/fn_addArsenalAction.sqf
+++ b/functions/fn_addArsenalAction.sqf
@@ -7,6 +7,7 @@
 */
 
 if (!hasInterface) exitWith {};
+waitUntil { !isNil "ace_interact_menu_fnc_createAction" };
 params ["_box", "_side"];
 if (side player != _side) exitWith {};
 

--- a/functions/fn_addGarageActions.sqf
+++ b/functions/fn_addGarageActions.sqf
@@ -7,6 +7,7 @@
 */
 
 if (!hasInterface) exitWith {};
+waitUntil { !isNil "ace_interact_menu_fnc_createAction" };
 params ["_pad", "_side"];
 if (side player != _side) exitWith {};
 

--- a/functions/fn_addRPInteractions.sqf
+++ b/functions/fn_addRPInteractions.sqf
@@ -1,17 +1,23 @@
 /*
     Funktion: CR_fnc_addRPInteractions
     Zweck: Fügt clientseitig einfache RP-Interaktionen hinzu. Aktuell
-    erhalten alle Spieler eine Aktion "Ausweis zeigen", mit der sie
-    anderen in der Nähe ihre Identität präsentieren können. Dies soll
+    erhalten alle Spieler eine ACE-Selbstaktion "Ausweis zeigen", mit der
+    sie anderen in der Nähe ihre Identität präsentieren können. Dies soll
     Rollenspielgespräche zwischen Polizisten und Räubern fördern.
 */
 
 if (!hasInterface) exitWith {};
+waitUntil { !isNil "ace_interact_menu_fnc_createAction" };
 
-player addAction [
+private _action = [
+    "showID",
     "Ausweis zeigen",
+    "",
     {
-        params ["_target", "_caller", "_actionId", "_arguments"];
-        [_caller] remoteExec ["CR_fnc_showID", 0];
-    }
-];
+        params ["_target", "_player", "_args"];
+        [_player] remoteExec ["CR_fnc_showID", 0];
+    },
+    { true }
+] call ace_interact_menu_fnc_createAction;
+
+[player, 1, ["ACE_SelfActions"], _action] call ace_interact_menu_fnc_addActionToObject;

--- a/functions/fn_addRobberyActions.sqf
+++ b/functions/fn_addRobberyActions.sqf
@@ -11,6 +11,7 @@
 params ["_obj"];
 
 if (!hasInterface) exitWith {};
+waitUntil { !isNil "ace_interact_menu_fnc_createAction" };
 
 private _type = _obj getVariable ["CR_target", ""];
 


### PR DESCRIPTION
## Summary
- wait for ACE menus to initialize before adding interactions
- convert "Ausweis zeigen" to an ACE self-action
- whitelist mission functions in `CfgRemoteExec` to allow remote execution

## Testing
- `make test` *(fails: No rule to make target 'test')*


------
https://chatgpt.com/codex/tasks/task_e_68bf33e916b08328b2fe5f7919da96b4