### PR TITLE
Implement ACE gas station robbery and mandatory CBA settings

### DIFF
--- a/CfgFunctions.hpp
+++ b/CfgFunctions.hpp
@@ -43,6 +43,7 @@ class CfgFunctions
             class triggerAlarm {};          // fn_triggerAlarm.sqf
             class notifyCops {};            // fn_notifyCops.sqf
             class robberyPreventedCops {};  // fn_robberyPreventedCops.sqf
+            class startRobberyServer {};    // fn_startRobberyServer.sqf
         };
 
         // --- Polizei / Einsatzmittel ---

--- a/cba_settings.sqf
+++ b/cba_settings.sqf
@@ -1,0 +1,6 @@
+ace_advanced_fatigue_enabled = false;
+ace_overheating_enabled = false;
+ace_medical_level = 2;
+ace_medical_treatment_advancedBandages = 2;
+ace_medical_medicSetting_SurgicalKit = 0;
+ace_medical_treatment_allowSelfStitching = 1;

--- a/description.ext
+++ b/description.ext
@@ -63,6 +63,7 @@ class CfgRemoteExec
         class CR_fnc_spawnVehicle        { allowedTargets = 2; };
         class CR_fnc_spawnGasLoot        { allowedTargets = 2; };
         class CR_fnc_postGasRobbery      { allowedTargets = 2; };
+        class CR_fnc_startRobberyServer  { allowedTargets = 2; };
         class CR_fnc_safehouseSuccess    { allowedTargets = 2; };
         class CR_fnc_startSiren          { allowedTargets = 2; };
         class CR_fnc_stopSiren           { allowedTargets = 2; };

--- a/functions/fn_startRobberyServer.sqf
+++ b/functions/fn_startRobberyServer.sqf
@@ -1,0 +1,38 @@
+/*
+    Funktion: CR_fnc_startRobberyServer
+    Zweck: Serverseitige Logik für den Tankstellenraub
+*/
+params ["_target", "_mode", ["_robber", objNull]];
+if (!isServer) exitWith {};
+
+switch (_mode) do {
+    case "start": {
+        if (_target getVariable ["CR_isLocked", false]) exitWith {};
+        _target setVariable ["CR_isLocked", true, true];
+        [_target] spawn {
+            params ["_tgt"];
+            uiSleep 160;
+            if (_tgt getVariable ["CR_isLocked", false]) then {
+                _tgt setVariable ["CR_isLocked", false, true];
+            };
+        };
+    };
+    case "cancel": {
+        _target setVariable ["CR_isLocked", false, true];
+    };
+    case "success": {
+        if (!(_target getVariable ["CR_isLocked", false])) exitWith {};
+        private _crate = "Box_NATO_Ammo_F" createVehicle (getMarkerPos "mrk_gasLoot");
+        _crate addItemCargoGlobal ["TrainingMine_Mag", 1];
+        [_crate] spawn {
+            params ["_box"];
+            uiSleep 900;
+            deleteVehicle _box;
+        };
+        [_target] spawn {
+            params ["_tgt"];
+            uiSleep 600;
+            _tgt setVariable ["CR_isLocked", false, true];
+        };
+    };
+};

--- a/initPlayerLocal.sqf
+++ b/initPlayerLocal.sqf
@@ -1,0 +1,65 @@
+/*
+    initPlayerLocal.sqf – clientseitige Initialisierung für den Tankstellenraub
+*/
+if (!hasInterface) exitWith {};
+
+player enableStamina false;
+
+private _t0 = time;
+waitUntil {
+    (isClass (configFile >> "CfgPatches" >> "ace_main") && {!isNil "ace_interact_menu_fnc_createAction"})
+    || {time > _t0 + 10}
+};
+if (isNil "ace_interact_menu_fnc_createAction") exitWith {};
+
+CR_fnc_addGasRobberyAction = {
+    private _target = missionNamespace getVariable ["CR_gasStationTarget", objNull];
+    if (isNull _target) exitWith {};
+    if (_target getVariable ["CR_actionAdded", false]) exitWith {};
+    _target setVariable ["CR_actionAdded", true];
+
+    private _action = [
+        "CR_RobGas",
+        "Tankstelle ausrauben",
+        "",
+        {
+            params ["_target", "_player", "_params"];
+            [_target, "start"] remoteExecCall ["CR_fnc_startRobberyServer", 2];
+            [
+                150,
+                [_target, _player],
+                {
+                    params ["_args"]; _args params ["_tgt", "_pl"];
+                    [_tgt, "success", _pl] remoteExecCall ["CR_fnc_startRobberyServer", 2];
+                },
+                {
+                    params ["_args"]; _args params ["_tgt", "_pl"];
+                    [_tgt, "cancel"] remoteExecCall ["CR_fnc_startRobberyServer", 2];
+                },
+                "Tankstelle wird ausgeraubt...",
+                {
+                    params ["_args"]; _args params ["_tgt", "_pl"];
+                    alive _pl && { _pl distance _tgt <= 3 }
+                },
+                [],
+                true
+            ] call ace_common_fnc_progressBar;
+        },
+        {
+            params ["_target", "_player", "_params"];
+            (side _player == civilian)
+            && { _player distance _target <= 3 }
+            && { !(_target getVariable ["CR_isLocked", false]) }
+        }
+    ] call ace_interact_menu_fnc_createAction;
+
+    [_target, 0, ["ACE_MainActions"], _action] call ace_interact_menu_fnc_addActionToObject;
+};
+
+[] call CR_fnc_addGasRobberyAction;
+
+player addEventHandler ["Respawn", {
+    params ["_unit"];
+    _unit enableStamina false;
+    [] call CR_fnc_addGasRobberyAction;
+}];

--- a/initServer.sqf
+++ b/initServer.sqf
@@ -1,0 +1,8 @@
+/*
+    initServer.sqf – serverseitige Initialisierung für den Tankstellenraub
+*/
+if (!isServer) exitWith {};
+
+if (!isNil "CR_gasStationTarget") then {
+    CR_gasStationTarget setVariable ["CR_isLocked", false, true];
+};


### PR DESCRIPTION
## Summary
- Add server-side logic for gas station robbery with timed crate spawn and cooldown
- Register ACE interaction locally with stamina disabled and fail-safe cleanup
- Enforce ACE medical, stamina and overheating settings via mission files

## Testing
- `sqflint functions/fn_startRobberyServer.sqf` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c00b090ef48328bedba878613c7080