### PR TITLE
Add jewelry and warehouse heists

### DIFF
--- a/CfgFunctions.hpp
+++ b/CfgFunctions.hpp
@@ -36,9 +36,13 @@ class CfgFunctions
             file = "functions";
             class robGasStation {};         // fn_robGasStation.sqf
             class robATM {};                // fn_robATM.sqf
+            class robJewelry {};           // fn_robJewelry.sqf
+            class robWarehouse {};         // fn_robWarehouse.sqf
             class startRobbery {};          // fn_startRobbery.sqf
             class pickupLoot {};            // fn_pickupLoot.sqf
             class spawnGasLoot {};          // fn_spawnGasLoot.sqf
+            class spawnJewelryLoot {};      // fn_spawnJewelryLoot.sqf
+            class spawnWarehouseLoot {};    // fn_spawnWarehouseLoot.sqf
             class postGasRobbery {};        // fn_postGasRobbery.sqf
             class triggerAlarm {};          // fn_triggerAlarm.sqf
             class notifyCops {};            // fn_notifyCops.sqf

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,388 @@
+# CnR:NG → ArmA 3 (ACE³/CBA) — Design & Implementation Plan
+
+**Projektziel**: Ein „Cops & Robbers“-Szenario in ArmA 3, angelehnt an CnR:NG-Mechaniken (Robberies, Heists, Trucking, Skills, Police/Medic Gameplay), umgesetzt mit **ACE³** (Interaktionsframework), **CBA** (Events/Settings), optional **RHS/NiArms** (Content) und klarer Server/Client-Trennung.
+
+Persistenz über iniDB2/extDB3 wird vorerst ausgelassen; der Fokus liegt auf spielbaren Überfällen.
+
+---
+
+## 1) Inspirationsbasis (aus CnR:NG)
+
+* **Robberies & Heists**: Tankstellen, ATMs, Tresor/Bank, Juwelier, Lagerhalle, etc.
+* **Trucking 2.0-Ideen**: Routenwahl, Gütertypen, Dringlichkeitsaufträge, Marktpreise, Achievements.
+* **Skill-/Role-Gates**: Orte/Interaktionen sind skill-/rollenbasiert (z. B. PO öffnet Poller automatisch).
+* **Police/Medic QoL**: Schnelle Alarme, Siegezonen, UI-Feedback, kleine Regeln (Jailtime, Manhunt).
+
+*(Wir adaptieren die Ideen systemisch — konkrete UI/Kommandos werden ACE-Interaktionen und Marker/Notifications.)*
+
+---
+
+## 2) MVP-Umfang (Phase 1)
+
+1. **Fraktionen & Spawns**: BLUFOR=Cops, CIV=Robbers, je 3 feste Spawnpunkte.
+2. **ACE-Interaktionen**:
+
+   * Tankstellenraub per NPC/Objekt („Ausrauben“, 150 s Progress).
+   * ATM-Hack (Tool benötigt), Tresor-Interaktion (Schneidbrenner/Sprengsatz Gate).
+   * Juwelierüberfall (Diamanten klauen, 180 s Progress).
+   * Lagerhallenraub (Plündern, 240 s Progress).
+3. **Alarm-/Benachrichtigungssystem**: Startet Robbery → setzt Marker + Broadcast an Cops, Throttle & Cooldowns.
+4. **Beutecontainer**: Kiste spawnt beim Erfolg; Transport zum **Fence/Safehouse** gegen Geld.
+5. **Polizei-Mechaniken**: Festnehmen/Abführen, Ticketieren, Jail (45–180 s), Beute beschlagnahmen.
+6. **Ökonomie (basic)**: Cash, Item-Preise, Heist-Belohnungen, simple Marktparameter.
+
+---
+
+## 3) Mods & Tech-Stack
+
+* **Hard**: CBA_A3, ACE³ (Interaction, Medical light, Explosives, Logistics, ProgressBar APIs).
+* **Optional**: RHS/NiArms (Gear/Weapons), Task Force/ACRE (Funk), Community Skins.
+
+---
+
+## 4) Missionsstruktur & Dateien
+
+```
+missionRoot/
+  description.ext
+  init.sqf
+  initServer.sqf
+  initPlayerLocal.sqf
+  cba_settings.sqf
+  CfgFunctions.hpp
+  functions/
+    fn_setupTeams.sqf
+    fn_initRobberyTargets.sqf
+    fn_addRobberyActions.sqf
+    fn_startRobbery.sqf
+    fn_finishRobbery.sqf
+    fn_failRobbery.sqf
+    fn_notifyCops.sqf
+    fn_spawnLootCrate.sqf
+    fn_registerArrest.sqf
+    fn_confiscateLoot.sqf
+    fn_economy_getPrice.sqf
+    fn_economy_payout.sqf
+    fn_skill_check.sqf
+    fn_trucking_offerJobs.sqf (Phase 2)
+    ...
+  sounds/
+  mission.sqm (benannte Objekte/NPCs/Marker)
+```
+
+---
+
+## 5) Cfg & Engine-Hooks
+
+**description.ext**
+
+* CfgFunctions inkl. `tag = "CR"`.
+* RemoteExec für erlaubte Funktionen.
+* Respawn-Einstellungen, ACE RscTitles (falls Progress/Notifications custom), CfgSounds (Alarme).
+
+**CfgFunctions.hpp (Beispiel)**
+
+```cpp
+class CfgFunctions {
+  class CR {
+    tag = "CR";
+    class Core {
+      file = "functions";
+      class setupTeams {};
+      class initRobberyTargets {};
+      class addRobberyActions {};
+      class startRobbery {};
+      class finishRobbery {};
+      class failRobbery {};
+      class notifyCops {};
+      class spawnLootCrate {};
+      class registerArrest {};
+      class confiscateLoot {};
+      class economy_getPrice {};
+      class economy_payout {};
+      class skill_check {};
+      class trucking_offerJobs {}; // Phase 2
+    };
+  };
+};
+```
+
+**remoteExec (description.ext)**
+
+```cpp
+class CfgRemoteExec {
+  class Functions {
+    mode = 1; jip = 1;
+    class CR_fnc_notifyCops { allowedTargets = 2; } // Server → Clients
+    class CR_fnc_startRobbery { allowedTargets = 2; } // Server bestätigt Start → Alle
+    class CR_fnc_finishRobbery { allowedTargets = 2; }
+    class CR_fnc_failRobbery   { allowedTargets = 2; }
+    class CR_fnc_spawnLootCrate{ allowedTargets = 2; }
+  };
+};
+```
+
+**initServer.sqf (Ausschnitt)**
+
+```sqf
+[] call CR_fnc_setupTeams;
+[] call CR_fnc_initRobberyTargets;
+publicVariable "CR_RobberySites"; // [{obj, type, name, cooldown}, ...]
+CR_Economy = call compile preprocessFileLineNumbers "config\economy.sqf"; // optional
+```
+
+**initPlayerLocal.sqf (Ausschnitt)**
+
+```sqf
+[] call CR_fnc_addRobberyActions; // Client-side ACE actions on discovered targets
+```
+
+---
+
+## 6) ACE-Interaktionen (Pattern)
+
+**Ziel**: Scripted Actions pro Zieltyp (Tankstelle/ATM/Tresor), mit `condition` (Cooldown, Tool/Skill) & `statement`.
+
+```sqf
+// fn_addRobberyActions.sqf (Client)
+{
+  private _obj  = _x select 0;
+  private _type = _x select 1; // "GAS", "ATM", "SAFE"
+  private _name = _x select 2;
+
+  private _action = [
+    format ["CR_%1Rob", _type],
+    format ["%1 ausrauben", _name],
+    "",
+    {
+      // onSelect
+      [(_this select 0), (_this select 1), _type] remoteExecCall ["CR_fnc_startRobbery", 2];
+    },
+    {
+      // condition
+      params ["_target","_player","_params"];
+      (alive _player) &&
+      !(_target getVariable ["CR_busy", false]) &&
+      [("robbery"), _player] call CR_fnc_skill_check &&
+      (serverTime > (_target getVariable ["CR_cdUntil", 0]))
+    }
+  ] call ace_interact_menu_fnc_createAction;
+
+  [_obj, 0, ["ACE_MainActions"], _action] call ace_interact_menu_fnc_addActionToObject;
+} forEach (missionNamespace getVariable ["CR_RobberySites", []]);
+```
+
+**Progress & QTE**: ACE Progressbar (`ace_common_fnc_progressBar`) oder QuickTime-Event-Mod (optional) einbinden.
+
+---
+
+## 7) Robbery-Flow (Server)
+
+**Start** (`CR_fnc_startRobbery`)
+
+```sqf
+params ["_obj","_player","_type"];
+if (!isServer) exitWith {};
+if (_obj getVariable ["CR_busy", false]) exitWith {};
+
+_obj setVariable ["CR_busy", true, true];
+_obj setVariable ["CR_cdUntil", serverTime + 600, true]; // 10 min cooldown
+
+// Broadcast Marker + Alarm
+[[_obj, _type, _player], "CR_fnc_notifyCops"] remoteExec ["call", 0, true];
+
+// Start a server-side timer
+[_obj, _player, _type] spawn {
+  params ["_o","_p","_t"];
+  private _dur = switch (_t) do {case "GAS":150; case "ATM":180; case "SAFE":210; default {150};};
+  private _ok = true;
+  for "_i" from 1 to _dur do {
+    sleep 1;
+    if (!alive _p || (_p distance _o) > 5) exitWith {_ok = false};
+  };
+  if (_ok) then {
+    [_o, _p, _t] call CR_fnc_finishRobbery;
+  } else {
+    [_o, _p, _t] call CR_fnc_failRobbery;
+  };
+};
+```
+
+**Erfolg** (`CR_fnc_finishRobbery`)
+
+```sqf
+params ["_obj","_player","_type"];
+if (!isServer) exitWith {};
+[_obj, _type] call CR_fnc_spawnLootCrate; // crate with class "CR_Loot_%1"
+[_player, _type] call CR_fnc_economy_payout; // optional sofortiger Teilbetrag
+_obj setVariable ["CR_busy", false, true];
+```
+
+**Fehlschlag** (`CR_fnc_failRobbery`)
+
+```sqf
+params ["_obj","_player","_type"];
+_obj setVariable ["CR_busy", false, true];
+// Optional: Cop-Bonus für Verhinderung
+```
+
+**Notifys** (`CR_fnc_notifyCops`)
+
+```sqf
+params ["_payload"]; // [_obj,_type,_player]
+_payload params ["_obj","_type","_plr"];
+
+// Marker für Cops erstellen (client-side on each Cop)
+if (side player isEqualTo west) then {
+  private _m = createMarkerLocal [format ["CR_m_%1", diag_tickTime], position _obj];
+  _m setMarkerTypeLocal "mil_warning";
+  _m setMarkerTextLocal format ["%1 - %2", _type, name _plr];
+  _m setMarkerColorLocal "ColorRed";
+  // RscTitle / hintC / cutText für Audio/Visuelles Feedback
+};
+```
+
+---
+
+## 8) Polizei-Loop
+
+* **Festnahme**: `addAction`/ACE-Interaktion „Festnehmen“ (nur on-foot).
+* **Ticket/Jail**: Menüs via ACE-Untermenü oder Dialog; Jailzeit 45–180 s.
+* **Beschlagnahme**: Interaktion am Beutecontainer/Spieler-Inventar; Cash & Items an Staat.
+
+**Arrest (Server-Stub)**
+
+```sqf
+// CR_fnc_registerArrest.sqf
+params ["_cop","_sus"];
+if (!isServer) exitWith {};
+// remove weapons, set captive, moveInCargo policeCar, set variable jail, timer, etc.
+```
+
+---
+
+## 9) Economy & Skills (Basismodell)
+
+* **Ökonomie**: Preisfunktionen per Tabelle + Multiplikatoren (Heat/Market). Beispiel: `CR_Economy select "GAS_BASE"` × `robberyTierMult`.
+* **Skills**: `CR_fnc_skill_check` liest per Profile/DB: `robbery>=X` → erlaube High-Tier Ziele; Cops-Grade → Poller öffnen.
+
+```sqf
+// CR_fnc_skill_check.sqf
+params ["_action","_unit"];
+private _lvl = _unit getVariable [format ["CR_skill_%1", _action], 0];
+_lvl >= 1;
+```
+
+---
+
+## 10) Trucking (Phase 2 Entwurf)
+
+* **Jobboard**: Terminalobjekte mit ACE-„Trucking-Jobs ansehen“ → Liste generierter Routen (Start-Hub → Ziel, Gütertyp, Zeitlimit, Bonus).
+* **Dynamischer Markt**: Güterpreise ±%/Zeit, seltene „Urgent Cargo“. Skills gates (Driver-Level) für Spezialaufträge.
+* **Datenpunkte**: `trucking_jobs`, `delivered_goods`, `player_driver_stats`.
+
+---
+
+## 11) Siegezonen & Dome (optional)
+
+* Bank/Heist-Orte in „Siege“-Triggern: Inside → bestimmte Regeln (z. B. Waffen erlaubt, Timer, Respawn-Block).
+* Visual: Dome/Marker, Audio-Cues.
+
+---
+
+## 12) Testing-Plan
+
+1. **Unit Tests**: Lokal Robbery-Start/Abbruch, Cooldowns, Marker.
+2. **MP-JIP**: Join-in-Progress korrekt (Marker/Busy-Status).
+3. **Balance**: Zeiten & Payouts anpassen; Heat/Police-Reaction-Tuning.
+4. **Security**: RemoteExec-Whitelist, Anti-Exploit (Spam, Dupes, Teleport, Gearfarm).
+
+---
+
+## 13) Roadmap
+
+* **Sprint 1 (MVP)**: Spawns, ACE-Interaktionen, Tankstellen/ATM/Tresor, Alarme, Kiste, Cops-Arrest/Ticket/Jail, Basiseconomy.
+* **Sprint 2**: Juwelier & Lagerhalle, Fence/Safehouse, Heat/Manhunt, Cop-Reputation, einfache Daily Events.
+* **Sprint 3**: Trucking-Board, Gütermarkt, Driver-Skill, Achievements.
+* **Sprint 4**: High-Tier Heists (Bank/Jewelry/Warehouse), Siegezonen, Dome, Anti-Missbrauch.
+
+---
+
+## 14) mission.sqm — Benannte Objekte/Marker (Pflicht)
+
+* NPCs/Objekte: `cr_gas_*`, `cr_atm_*`, `cr_safe_*`, `cr_fence_01` (Fence/Safehouse), `cr_pd_*` (Police-Stützpunkte).
+* Marker: `cr_spawn_cop_1..3`, `cr_spawn_civ_1..3`.
+* Optional Hubs: `cr_truckhub_*` (Phase 2).
+
+---
+
+## 15) CBA Settings (cba_settings.sqf, Beispiele)
+
+```sqf
+// ACE Interaction Keybinds usw. nur Beispiel — final im Spiel ändern
+force force ace_interaction_enableTeamManagement = true;
+force force ace_medical_level = 1; // Basic
+force force ace_frag_reflectionsEnabled = 1;
+```
+
+---
+
+## 16) Known Good Patterns & Stolperfallen
+
+* ACE-Action-Code läuft **clientseitig** (UI) — serverseitige Autorität für state changes (robbery, payouts).
+* JIP: `setVariable public` + Replays (onPlayerConnected → Sync Busy/Cooldowns).
+* RemoteExec strikt whitelisten; keine `call compile` aus Clientdaten.
+* Progressbars/Cancel: Abstand/Line-of-sight check, Combat-Interrupt.
+* **Performance**: Keine OnEachFrame-Schleifen für triviale Checks; Timers/Triggers nutzen.
+
+---
+
+## 17) To‑Do (für GitHub Issues)
+
+* [ ] ACE-Aktions-Wrapper + Utilitys (`CR_fnc_addAction`, `CR_fnc_canRob`)
+* [ ] Robbery-Core (start/finish/fail) + Notify-System
+* [ ] Economy-Table & Payouts
+* [ ] Police: Arrest/Jail/Ticket + Confiscate
+* [ ] LootCrate-Spawner + Fence-Sell
+* [ ] CBA Settings Baseline
+* [ ] mission.sqm: Platzhalter-Objekte/Marker benennen
+* [ ] Trucking Phase 2 Scaffolding
+
+---
+
+## 18) Appendix — Mini‑Snippets
+
+**Economy Payout**
+
+```sqf
+// CR_fnc_economy_payout.sqf
+params ["_unit","_type"];
+private _base = switch (_type) do {case "GAS": 1200; case "ATM": 2500; case "SAFE": 4000; default {1000};};
+private _heat = missionNamespace getVariable ["CR_heat",1];
+private _pay  = round (_base * _heat);
+_unit addRating 100; // flavor
+_unit addItemToUniform "ACE_moneyroll"; // Platzhalter
+[_unit, _pay] call CR_fnc_addCash; // implementieren
+```
+
+**Cooldown Utility**
+
+```sqf
+// utility: CR_fnc_onCooldown
+params ["_obj"];
+serverTime < (_obj getVariable ["CR_cdUntil", 0]);
+```
+
+**Fence Sell (Server)**
+
+```sqf
+params ["_crate","_player"];
+private _val = (_crate getVariable ["CR_lootValue", 0]);
+[_player, _val] call CR_fnc_addCash;
+deleteVehicle _crate;
+```
+
+---
+
+**Fazit**: Dieses Dokument ist die Blaupause. Als nächstes: Issue‑Board füllen, dann Sprint 1 sauber umsetzen. Danach Trucking 2.0. ArmA lebt — und jetzt kriegt’s frische CnR‑Mechaniken.
+

--- a/MASTER_PLAN.md
+++ b/MASTER_PLAN.md
@@ -1,0 +1,33 @@
+# ArmA 3 Cops & Robbers — Master Plan
+
+This document outlines the overarching plan for developing the Cops & Robbers scenario in ArmA 3. It supplements the detailed design draft in `DESIGN.md` and aligns with current guidance from the ArmA 3, ACE3 and CBA developer communities.
+
+## 1. Guiding References
+- **ArmA 3 Developer Guide** – mission structure, SQF conventions and multiplayer best practices.
+- **ACE3 Developer Guide** – interaction framework, medical and explosive APIs, and recommended progress bar usage.
+- **CBA Developer Guide** – event handlers, settings system and function registration conventions.
+
+Following these resources ensures that scripting patterns, network behaviour and configuration files remain compatible with the broader mod ecosystem.
+
+## 2. Milestones
+1. **MVP** – faction spawns, robbery interactions, notifications, loot crates, basic police mechanics and economy.
+2. **Trucking & Advanced Economy** – dynamic job board, market pricing and driver skills.
+3. **High‑Tier Heists & Siege Zones** – bank/jewelry targets, zone rules and anti‑abuse measures.
+
+Each milestone is delivered in iterative sprints, adhering to the guidelines above for scripting standards and network security.
+
+## 3. Implementation Standards
+- Use CBA function and event frameworks for modularity.
+- Register ACE interactions client‑side while validating actions server‑side.
+- Whitelist remote executions in `description.ext` per ArmA 3 security recommendations.
+- Configure gameplay options via `cba_settings.sqf` so servers can override defaults.
+
+## 4. Testing & Validation
+- Local and dedicated server tests follow the procedures outlined in the ArmA 3 mission testing guide.
+- ACE3 and CBA debug tools assist with verifying interaction conditions, event firing and network synchronisation.
+- Automated checks (`make test`) are executed where available to catch scripting errors early.
+
+## 5. Documentation & Maintenance
+- Keep function headers and file organisation consistent with CBA and ACE3 templates.
+- Reference changes back to this master plan and the detailed design to maintain alignment.
+

--- a/functions/fn_addRobberyActions.sqf
+++ b/functions/fn_addRobberyActions.sqf
@@ -1,7 +1,7 @@
 /*
     Datei: functions/fn_addRobberyActions.sqf
     Funktion: CR_fnc_addRobberyActions
-    Zweck: Fügt einem Zielobjekt (Tankstelle/ATM/Tresor) passende ACE-Aktionen hinzu.
+    Zweck: Fügt einem Zielobjekt (Tankstelle/ATM/Tresor/Juwelier/Lagerhalle) passende ACE-Aktionen hinzu.
     Aufruf: [_obj] remoteExec ["CR_fnc_addRobberyActions", 0, true];  // vom Server aus
 */
 
@@ -29,6 +29,8 @@ CR_fnc_addRobberyActions = {
         if (_lname select [0,12] isEqualTo "gas_station_") then { _type = "gas"; };
         if (_lname select [0,4]  isEqualTo "atm_")          then { _type = "atm"; };
         if (_lname select [0,6]  isEqualTo "vault_")        then { _type = "vault"; };
+        if (_lname select [0,8]  isEqualTo "jewel_" )       then { _type = "jewelry"; };
+        if (_lname select [0,10] isEqualTo "warehouse")    then { _type = "warehouse"; };
     };
 
     // Hilfsfunktion: Aktion hinzufügen
@@ -111,6 +113,32 @@ CR_fnc_addRobberyActions = {
                 ([_tgt,_pl] call _condCivilNear) && { !(_tgt getVariable ["robbed", false]) }
             };
             [_obj, "CR_robVault", "Tresor knacken", _onExec, _cond] call _addActionTo;
+        };
+
+        case "jewelry": {
+            private _onExec = {
+                params ["_tgt","_pl"];
+                if (_tgt getVariable ["robbed", false]) exitWith { ["Bereits geplündert",2] call ace_common_fnc_displayTextStructured; };
+                [_tgt, _pl] call CR_fnc_robJewelry;
+            };
+            private _cond = {
+                params ["_tgt","_pl"];
+                ([_tgt,_pl] call _condCivilNear) && { !(_tgt getVariable ["robbed", false]) }
+            };
+            [_obj, "CR_robJewelry", "Juwelier ausrauben", _onExec, _cond] call _addActionTo;
+        };
+
+        case "warehouse": {
+            private _onExec = {
+                params ["_tgt","_pl"];
+                if (_tgt getVariable ["robbed", false]) exitWith { ["Bereits geplündert",2] call ace_common_fnc_displayTextStructured; };
+                [_tgt, _pl] call CR_fnc_robWarehouse;
+            };
+            private _cond = {
+                params ["_tgt","_pl"];
+                ([_tgt,_pl] call _condCivilNear) && { !(_tgt getVariable ["robbed", false]) }
+            };
+            [_obj, "CR_robWarehouse", "Lagerhalle plündern", _onExec, _cond] call _addActionTo;
         };
 
         default {

--- a/functions/fn_initRobberyTargets.sqf
+++ b/functions/fn_initRobberyTargets.sqf
@@ -5,7 +5,7 @@
     Zweck:
       - Scannt Missionsobjekte (NPCs/Objekte) und erkennt Raub-Ziele anhand Namensschema
         bzw. gesetzter Variablen.
-      - Unterstützte Typen: "gas", "atm", "vault".
+      - Unterstützte Typen: "gas", "atm", "vault", "jewelry", "warehouse".
       - Markiert Ziele mit Variablen, baut eine Server-Cacheliste und verteilt ACE-Aktionen
         JIP-sicher an alle Clients.
 
@@ -13,6 +13,8 @@
       gas_station_*   -> Tankstellen-Ziele (NPC oder Objekt in der Nähe)
       atm_*           -> Geldautomaten
       vault_*         -> Tresor
+      jewel_*         -> Juwelier
+      warehouse_*     -> Lagerhalle
 
     Multiplayer:
       - Server-only Scan & Cache, Verteilung via remoteExec (JIP=true).
@@ -57,11 +59,15 @@ CR_fnc_initRobberyTargets = {
         if (_lname find "gas_station_" isEqualTo 0) exitWith { "gas" };
         if (_lname find "atm_"          isEqualTo 0) exitWith { "atm" };
         if (_lname find "vault_"        isEqualTo 0) exitWith { "vault" };
+        if (_lname find "jewel_"       isEqualTo 0) exitWith { "jewelry" };
+        if (_lname find "warehouse_"   isEqualTo 0) exitWith { "warehouse" };
 
         // Klassenbasierte Heuristiken (optional, erweiterbar)
         if (_cls find "atm" > -1)      exitWith { "atm" };
         if (_cls find "fuel" > -1)     exitWith { "gas" };
         if (_cls find "vault" > -1)    exitWith { "vault" };
+        if (_cls find "jewel" > -1)    exitWith { "jewelry" };
+        if (_cls find "warehouse" > -1) exitWith { "warehouse" };
 
         "" // unbekannt
     };

--- a/functions/fn_robJewelry.sqf
+++ b/functions/fn_robJewelry.sqf
@@ -1,0 +1,41 @@
+/*
+    Funktion: CR_fnc_robJewelry
+    Zweck: Führt einen Juwelier-Überfall mit ACE-Fortschrittsanzeige durch.
+    Parameter:
+        0: OBJECT - Juwelier-Objekt
+        1: OBJECT - raubender Spieler
+*/
+
+CR_fnc_robJewelry = {
+    params ["_target", "_player"];
+    if (!hasInterface || {_player != ACE_player}) exitWith {};
+    if (_target getVariable ["CR_robbing", false]) exitWith {
+        ["Bereits im Gange",2] call ace_common_fnc_displayTextStructured;
+    };
+    _target setVariable ["CR_robbing", true, true];
+    [_target] remoteExec ["CR_fnc_startSiren", 2];
+    private _dur = 180;
+    private _cond = {
+        params ["_args", "_elapsed", "_target", "_err"];
+        _args params ["_tgt", "_pl"];
+        alive _pl && { _pl distance _tgt < 5 }
+    };
+    private _onFinish = {
+        params ["_args"];
+        _args params ["_tgt", "_pl"];
+        [_tgt] remoteExec ["CR_fnc_stopSiren", 2];
+        if (isServer) then { [_tgt] call CR_fnc_spawnJewelryLoot; } else { [_tgt] remoteExec ["CR_fnc_spawnJewelryLoot", 2]; };
+        [getPos _tgt, "Juwelier wird ausgeraubt!"] remoteExec ["CR_fnc_triggerAlarm", 2];
+        _tgt setVariable ["robbed", true, true];
+        _tgt setVariable ["CR_robbing", false, true];
+        ["Überfall erfolgreich!",3] call ace_common_fnc_displayTextStructured;
+    };
+    private _onFail = {
+        params ["_args"];
+        _args params ["_tgt", "_pl"];
+        [_tgt] remoteExec ["CR_fnc_stopSiren", 2];
+        _tgt setVariable ["CR_robbing", false, true];
+        ["Überfall abgebrochen",2] call ace_common_fnc_displayTextStructured;
+    };
+    [_dur, [_target, _player], _onFinish, _onFail, "Juwelier wird ausgeraubt…", _cond, [], true] call ace_common_fnc_progressBar;
+};

--- a/functions/fn_robWarehouse.sqf
+++ b/functions/fn_robWarehouse.sqf
@@ -1,0 +1,41 @@
+/*
+    Funktion: CR_fnc_robWarehouse
+    Zweck: Führt einen Lagerhallen-Überfall mit ACE-Fortschrittsanzeige durch.
+    Parameter:
+        0: OBJECT - Lagerhallen-Objekt
+        1: OBJECT - raubender Spieler
+*/
+
+CR_fnc_robWarehouse = {
+    params ["_target", "_player"];
+    if (!hasInterface || {_player != ACE_player}) exitWith {};
+    if (_target getVariable ["CR_robbing", false]) exitWith {
+        ["Bereits im Gange",2] call ace_common_fnc_displayTextStructured;
+    };
+    _target setVariable ["CR_robbing", true, true];
+    [_target] remoteExec ["CR_fnc_startSiren", 2];
+    private _dur = 240;
+    private _cond = {
+        params ["_args", "_elapsed", "_target", "_err"];
+        _args params ["_tgt", "_pl"];
+        alive _pl && { _pl distance _tgt < 5 }
+    };
+    private _onFinish = {
+        params ["_args"];
+        _args params ["_tgt", "_pl"];
+        [_tgt] remoteExec ["CR_fnc_stopSiren", 2];
+        if (isServer) then { [_tgt] call CR_fnc_spawnWarehouseLoot; } else { [_tgt] remoteExec ["CR_fnc_spawnWarehouseLoot", 2]; };
+        [getPos _tgt, "Lagerhalle wird geplündert!"] remoteExec ["CR_fnc_triggerAlarm", 2];
+        _tgt setVariable ["robbed", true, true];
+        _tgt setVariable ["CR_robbing", false, true];
+        ["Überfall erfolgreich!",3] call ace_common_fnc_displayTextStructured;
+    };
+    private _onFail = {
+        params ["_args"];
+        _args params ["_tgt", "_pl"];
+        [_tgt] remoteExec ["CR_fnc_stopSiren", 2];
+        _tgt setVariable ["CR_robbing", false, true];
+        ["Überfall abgebrochen",2] call ace_common_fnc_displayTextStructured;
+    };
+    [_dur, [_target, _player], _onFinish, _onFail, "Lagerhalle wird geplündert…", _cond, [], true] call ace_common_fnc_progressBar;
+};

--- a/functions/fn_spawnJewelryLoot.sqf
+++ b/functions/fn_spawnJewelryLoot.sqf
@@ -1,0 +1,11 @@
+CR_fnc_spawnJewelryLoot = {
+  if (!isServer) exitWith {};
+  params ["_anchor"];
+  private _pos = getPosATL _anchor vectorAdd [0,0.8,0];
+  private _crate = createVehicle ["Box_East_Ammo_F", _pos, [], 0, "NONE"];
+  clearBackpackCargoGlobal _crate;
+  clearItemCargoGlobal _crate;
+  clearWeaponCargoGlobal _crate;
+  clearMagazineCargoGlobal _crate;
+  _crate addItemCargoGlobal ["ACE_moneyroll", 5];
+};

--- a/functions/fn_spawnWarehouseLoot.sqf
+++ b/functions/fn_spawnWarehouseLoot.sqf
@@ -1,0 +1,11 @@
+CR_fnc_spawnWarehouseLoot = {
+  if (!isServer) exitWith {};
+  params ["_anchor"];
+  private _pos = getPosATL _anchor vectorAdd [0,0.8,0];
+  private _crate = createVehicle ["Box_IND_Ammo_F", _pos, [], 0, "NONE"];
+  clearBackpackCargoGlobal _crate;
+  clearItemCargoGlobal _crate;
+  clearWeaponCargoGlobal _crate;
+  clearMagazineCargoGlobal _crate;
+  _crate addMagazineCargoGlobal ["TrainingMine_Mag", 5];
+};


### PR DESCRIPTION
## Summary
- expand robbery system with jewelry and warehouse heists including loot spawn scripts
- register new heist functions and update action/target detection
- remove iniDB2/extDB3 persistence references from design and master plan

## Testing
- `make test` *(fails: No rule to make target 'test')*


------
https://chatgpt.com/codex/tasks/task_e_68c035e6a9cc83288a27f24a1c9fb96e