### PR TITLE
Refine marker-based setup scripts

### DIFF
--- a/functions/fn_assignTasks.sqf
+++ b/functions/fn_assignTasks.sqf
@@ -10,11 +10,15 @@ if (!hasInterface) exitWith {};
 
     // ----- Hilfsfunktionen
     private _markerPos = {
-        params ["_candidates"];                     // ["cop_spawn","respawn_west"]
+        params ["_candidates"]; // ["cop_spawn","respawn_west"]
         private _pos = [0,0,0];
+
         {
-            if (markerExists _x) exitWith { _pos = getMarkerPos _x; };
+            if (markerExists _x) exitWith {
+                _pos = getMarkerPos _x;
+            };
         } forEach _candidates;
+
         _pos
     };
 

--- a/functions/fn_setupTeams.sqf
+++ b/functions/fn_setupTeams.sqf
@@ -43,7 +43,8 @@ params [
                 if (markerExists _name) then {
                     private _pos = getMarkerPos _name;
                     if (!(_pos isEqualTo [0,0,0])) then {
-                        _out pushBack [_name, _pos, format ["%1 #%2", _prefix, _i]];
+                        private _label = format ["%1 #%2", _prefix, _i];
+                        _out pushBack [_name, _pos, _label];
                     };
                 };
             };


### PR DESCRIPTION
## Summary
- ensure spawn marker loops build labelled entries explicitly
- expand task marker helper for clearer marker position lookup

## Testing
- ⚠️ `sqflint functions/fn_setupTeams.sqf` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0666f29e483288abe9c769470b350