### PR TITLE
Fix SQF syntax issues in interaction and team setup functions

### DIFF
--- a/functions/fn_addArsenalAction.sqf
+++ b/functions/fn_addArsenalAction.sqf
@@ -12,7 +12,6 @@ diag_log format ["[CR] addArsenalAction called: box=%1, side=%2, playerSide=%3",
 if (isNil "ace_interact_menu_fnc_createAction") then {
     diag_log "[CR][ERROR] ACE interact menu not available!";
     exitWith {};
-	;
 };
 
 if (!hasInterface) then {

--- a/functions/fn_assignTasks.sqf
+++ b/functions/fn_assignTasks.sqf
@@ -11,15 +11,9 @@ if (!hasInterface) exitWith {};
     // ----- Hilfsfunktionen
     private _markerPos = {
         params ["_candidates"]; // ["cop_spawn","respawn_west"]
-        private _pos = [0,0,0];
-
-        {
-            if (markerExists _x) exitWith {
-                _pos = getMarkerPos _x;
-            };
-        } forEach _candidates;
-
-        _pos
+        private _idx = _candidates findIf { markerExists _x };
+        if (_idx == -1) exitWith { [0,0,0] };
+        getMarkerPos (_candidates select _idx)
     };
 
     private _createOrUpdateTask = {

--- a/functions/fn_setupTeams.sqf
+++ b/functions/fn_setupTeams.sqf
@@ -19,11 +19,11 @@ params [
         {
             private _prefix = _x;
             for "_i" from 1 to 99 do {
-                private _name = format ["%1_%2", _prefix, _i];
+                private _name = _prefix + "_" + str _i;
                 if (markerExists _name) then {
                     private _pos = getMarkerPos _name;
                     if (!(_pos isEqualTo [0,0,0])) then {
-                        private _label = format ["%1 #%2", _prefix, _i];
+                        private _label = _prefix + " #" + str _i;
                         _out pushBack [_name, _pos, _label];
                     };
                 };


### PR DESCRIPTION
## Summary
- remove stray semicolon causing ACE interaction error
- simplify marker handling to avoid bad format usage
- use findIf to locate first existing marker for task assignment

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c0790e1c488328a3c8e6b5b32d52e9